### PR TITLE
Update docker file to set gomodule flag to on

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12.5
 
 WORKDIR /go/src/go-api-boilerplate
 
-RUN go get github.com/go-swagger/go-swagger/cmd/swagger \
+RUN GO111MODULE="on" go get github.com/go-swagger/go-swagger/cmd/swagger \
     github.com/Altoros/gorm-goose/cmd/gorm-goose
 
 COPY ./docker/go/entrypoint.sh ./docker/wait-for-it.sh /root/


### PR DESCRIPTION
Without this we get below error 
`package github.com/hashicorp/hcl/hcl/printer: cannot find package "github.com/hashicorp/hcl/hcl/printer" in any of:
        /usr/local/go/src/github.com/hashicorp/hcl/hcl/printer (from $GOROOT)
        /go/src/github.com/hashicorp/hcl/hcl/printer (from $GOPATH)`